### PR TITLE
Fixing manage_db_tables for mysql and add missing Schedule

### DIFF
--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -175,10 +175,20 @@ class bacula::director (
     show_diff => false,
   }
 
-  if $manage_db {
+  if $manage_db or $manage_db_tables {
     case $db_backend {
       'mysql'  : {
         include 'bacula::director::mysql'
+        class { 'bacula::director::mysql':
+          db_database   => $db_database,
+          db_host       => $db_host,
+          db_password   => $db_password,
+          db_port       => $db_port,
+          db_user       => $db_user,
+          db_user_host  => $db_user_host,
+          db_package    => $db_package,
+          manage_db     => $manage_db,
+        }
       }
 
       'postgresql' : {

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -178,7 +178,6 @@ class bacula::director (
   if $manage_db or $manage_db_tables {
     case $db_backend {
       'mysql'  : {
-        include 'bacula::director::mysql'
         class { 'bacula::director::mysql':
           db_database   => $db_database,
           db_host       => $db_host,

--- a/manifests/director/mysql.pp
+++ b/manifests/director/mysql.pp
@@ -68,9 +68,9 @@ class bacula::director::mysql (
   $db_parameters = "--host=${db_host} --user=${db_user} --password=${db_password} --port=${db_port} --database=${db_database}"
 
   exec { 'make_db_tables':
-    command     => "${make_db_tables_command} ${db_parameters}",
+    command     => "${make_db_tables_command} ${db_parameters} && echo tables create at $(date) >/etc/bacula/tables_created",
     environment => "db_name=${db_database}",
-    refreshonly => true,
+    creates     => '/etc/bacula/tables_created',
     logoutput   => true,
     require     => Package[$db_package],
   }

--- a/manifests/director/mysql.pp
+++ b/manifests/director/mysql.pp
@@ -69,6 +69,7 @@ class bacula::director::mysql (
 
   exec { 'make_db_tables':
     command     => "${make_db_tables_command} ${db_parameters}",
+    environment => "db_name=${db_database}",
     refreshonly => true,
     logoutput   => true,
     require     => Package[$db_package],

--- a/templates/bacula-dir.conf.erb
+++ b/templates/bacula-dir.conf.erb
@@ -305,6 +305,16 @@ Schedule {
   Run = Level=Incremental Mon-Sat at 23:05
 }
 
+# This does the catalog. It starts after the WeeklyCycle
+Schedule {
+  Name = "WeeklyCycleAfterBackup"
+  Run = Level=Full Monday at 23:10
+  Run = Level=Full Tuesday at 23:10
+  Run = Level=Full Wednesday at 23:10
+  Run = Level=Full Thursday at 23:10
+  Run = Level=Full Friday at 23:10
+}
+
 # These cycles are set up so that we can spread out the full backups of our
 # servers across the week. Some at the weekend, some mid-week.
 Schedule {


### PR DESCRIPTION
If manage_db is false, the manage_db_tables didn't work. This PR fixes this and adds the WeeklyCycleAfterBackup Schedule which is documented and referenced but wasn't defined.

Additionally the make_db_tables wasn't triggered as "refreshonly" can only be triggered by "notify" or through subscribing. With this fix it should be just triggered once (at least if the call to the script was successful).