### PR TITLE
remove all non-alnum characters as these arent allowed in variable names

### DIFF
--- a/templates/bacula-dir.conf.erb
+++ b/templates/bacula-dir.conf.erb
@@ -177,7 +177,7 @@ Pool {
   Name = "<%= @storage_server -%>:pool:catalog"
   # All Volumes will have the format director.catalog.date.time to ensure they
   # are kept unique throughout the operation and also aid quick analysis
-  Label Format = "${Job}.<%= @director_server -%>.${Counter<%= @director_server.split('.')[0].capitalize -%>Catalog+:p/3/0/r}"
+  Label Format = "${Job}.<%= @director_server -%>.${Counter<%= @director_server.split('.')[0].capitalize.gsub(/[^[:alnum:]]/,'') -%>Catalog+:p/3/0/r}"
   Pool Type = Backup
   # Clean up any we don't need, and keep them for a maximum of a month (in
   # theory the same time period for weekly backups from the clients)
@@ -192,7 +192,7 @@ Pool {
 
 # Create a Counter which will be used to label the catalog volumes on the system
 Counter {
-  Name    = "Counter<%= @director_server.split('.')[0].capitalize -%>Catalog"
+  Name    = "Counter<%= @director_server.split('.')[0].capitalize.gsub(/[^[:alnum:]]/,'') -%>Catalog"
   Minimum = 1
   Catalog = "<%= @director_server -%>:<%= @db_backend %>"
 }


### PR DESCRIPTION
If the fqdn of a host includes a - the variable can't be expanded any more. So remove all non alnum characters