### PR TITLE
Feature data encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,10 @@ The following lists all the class parameters the `bacula` class accepts.
 
 For directors, `clients` is a hash of clients.  The keys are the clients while
 the values are a hash of parameters. The parameters accepted are the same as
-the `bacula::client::config` define.
+the `bacula::client::config` define. But allows additionally to enable encryption
+through setting `pki_encryption` to true and defining `pki_keypair` and
+`pki_master_key` files (which have to be placed on the client first).
+Please note that the `pki_master_key` is the public key, only!
 
 ### console_password
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -47,6 +47,9 @@ class bacula::client (
   Boolean $tls_require              = true,
   Boolean $tls_verify_peer          = true,
   Boolean $use_tls                  = true,
+  Boolean $pki_encryption           = false,
+  String $pki_keypair               = '/var/lib/bacula/ssl/encryption_keypair.pem',
+  String $pki_master_key            = '/var/lib/bacula/ssl/certs/master.crt',
   ) {
 
   include 'bacula::common'

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -95,4 +95,13 @@ class bacula::client (
     hasrestart => true,
     require    => File['bacula-fd.conf'],
   }
+
+  if $pki_encryption {
+    Exec { 'create_keypair':
+      command => "/usr/bin/openssl genrsa -out private.key 4096 && /usr/bin/openssl req -new -key private.key -x509 -out public.crt -subj '/C=XX/ST=unknown/L=puppet-bacula/O=Bacula Backup/OU=backup/CN=${::fqdn}' && cat private.key public.crt >$pki_keypair && rm private.key public.crt",
+      creates => "$pki_keypair",
+      notify  => Service['bacula-fd'],
+    }
+  }
+
 }

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -48,6 +48,7 @@ class bacula::client (
   Boolean $tls_verify_peer          = true,
   Boolean $use_tls                  = true,
   Boolean $pki_encryption           = false,
+  Boolean $manage_pki_keypair       = true,
   String $pki_keypair               = '/var/lib/bacula/ssl/encryption_keypair.pem',
   String $pki_master_key            = '/var/lib/bacula/ssl/certs/master.crt',
   ) {
@@ -96,7 +97,7 @@ class bacula::client (
     require    => File['bacula-fd.conf'],
   }
 
-  if $pki_encryption {
+  if $pki_encryption and $manage_pki_keypair {
     Exec { 'create_keypair':
       command => "/usr/bin/openssl genrsa -out private.key 4096 && /usr/bin/openssl req -new -key private.key -x509 -out public.crt -subj '/C=XX/ST=unknown/L=puppet-bacula/O=Bacula Backup/OU=backup/CN=${::fqdn}' && cat private.key public.crt >$pki_keypair && rm private.key public.crt",
       creates => "$pki_keypair",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -198,8 +198,12 @@
 # [*volume_retention_incr*]
 #   Length of time to {retain volumes}[http://www.bacula.org/5.0.x-manuals/en/main/main/Configuring_Director.html#VolRetention] in
 #   the default incremental pool.
+#
 # [*pki_encryption*]
 #   If set to true encrypt backup on the client with the given keypair
+#
+# [*manage_pki_keypair*]
+#   If true a keypair will be created through puppet on every client, defaults to true
 #
 # [*pki_keypair*]
 #   Path to the client specific TLS keypair which is used to en- and decrypt the backup data
@@ -305,6 +309,7 @@ class bacula (
   String $volume_retention_full          = '1 Year',
   String $volume_retention_incr          = '10 Days',
   Boolean $pki_encryption                = false,
+  Boolean $manage_pki_keypair            = true,
   String $pki_keypair                    = '/var/lib/bacula/ssl/encryption_keypair.pem',
   String $pki_master_key                 = '/var/lib/bacula/ssl/certs/master.crt',
   ) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -198,6 +198,15 @@
 # [*volume_retention_incr*]
 #   Length of time to {retain volumes}[http://www.bacula.org/5.0.x-manuals/en/main/main/Configuring_Director.html#VolRetention] in
 #   the default incremental pool.
+# [*pki_encryption*]
+#   If set to true encrypt backup on the client with the given keypair
+#
+# [*pki_keypair*]
+#   Path to the client specific TLS keypair which is used to en- and decrypt the backup data
+#
+# [*pki_master_key*]
+#   Public TLS key of the master key to be able to decrypt backup even though the client keypair is lost
+#
 #
 # === Sample Usage
 #
@@ -295,6 +304,9 @@ class bacula (
   String $volume_retention_diff          = '40 Days',
   String $volume_retention_full          = '1 Year',
   String $volume_retention_incr          = '10 Days',
+  Boolean $pki_encryption                = false,
+  String $pki_keypair                    = '/var/lib/bacula/ssl/encryption_keypair.pem',
+  String $pki_master_key                 = '/var/lib/bacula/ssl/certs/master.crt',
   ) {
 
   include 'bacula::common'
@@ -387,6 +399,9 @@ class bacula (
       tls_require       => $tls_require,
       tls_verify_peer   => $tls_verify_peer,
       use_tls           => $use_tls,
+      pki_encryption    => $pki_encryption,
+      pki_keypair       => $pki_keypair,
+      pki_master_key    => $pki_master_key,
     }
   }
 

--- a/templates/bacula-fd.conf.erb
+++ b/templates/bacula-fd.conf.erb
@@ -51,6 +51,12 @@ FileDaemon {
   TLS Certificate = <%= @tls_cert %>
   TLS Key = <%= @tls_key %>
 <% end -%>
+<%- if @pki_encryption -%>
+  PKI Signatures = yes
+  PKI Encryption = yes
+  PKI Keypair = <%= @pki_keypair %>
+  PKI Master Key = <%= @pki_master_key %>
+<% end -%>
 }
 
 # Finally, set where the messages are going to go


### PR DESCRIPTION
This feature allows to configure encrypted backups. The needed TLS key/certificate is created at each client. The "master key" (certificate) has to be put on the client on a different way. 

The default is to not use encrypted backups. So this feature will only be used if $pki_encryption is set to true