### PR TITLE
Fix bacula catalog backup if database name is not bacula

### DIFF
--- a/templates/bacula-dir.conf.erb
+++ b/templates/bacula-dir.conf.erb
@@ -288,7 +288,7 @@ FileSet {
       Signature   = SHA1
       Compression = GZIP
     }
-    File = "/var/spool/bacula/bacula.sql"
+    File = "/var/spool/bacula/<%= @db_database %>.sql"
   }
 }
 


### PR DESCRIPTION
If the db_database variable is overwritten the backup still tried to
backup the bacula.sql dump although it has the name of the configured
database. So using the same variable for the catalog backup FileSet