### PR TITLE
Feature: enhance client configuration, setting Accurate = yes

### DIFF
--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -49,6 +49,9 @@
 # [*maximum_bandwidth*]
 #   Bandwidth limit for the bacula file director.  This can be used to prevent bacula from saturating network interfaces.
 #
+# [*allow_duplicate_jobs*]
+#   Allow duplicate jobs, if set to no the second job may be canceled if the first job is still running
+#
 # [*priority*]
 #   This directive permits you to control the order in which your jobs will be run by specifying a positive non-zero number. The
 #   higher the number, the lower the job priority. Assuming you are not running concurrent jobs, all queued jobs of priority
@@ -156,6 +159,7 @@ define bacula::client::config (
   Optional[String] $pool_full           = "${pool}.full",
   Optional[String] $pool_incr           = "${pool}.incr",
   Optional[String] $maximum_bandwidth   = undef,
+  Boolean $allow_duplicate_jobs         = false,
   Optional[String] $priority            = undef,
   Boolean $rerun_failed_levels          = false,
   Boolean $restore_enable               = true,

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -28,6 +28,9 @@
 # [*base*]
 #   The job to use as a base.  Default to undef.
 #
+# [*accurate*]
+#   Set Accurate = yes for job definition (defaults to now unless *base* is specified)
+#
 # [*pool*]
 #   The pool used by the client for backups
 #
@@ -144,6 +147,10 @@ define bacula::client::config (
   String $director_server               = "bacula.${facts['domain']}",
   String $fileset                       = 'Basic:noHome',
   Optional[String] $base                = undef,
+  Boolean $accurate                     = $base ? {
+    undef   => false,
+    default => true,
+  },
   String $pool                          = 'default',
   Optional[String] $pool_diff           = "${pool}.differential",
   Optional[String] $pool_full           = "${pool}.full",

--- a/templates/client_config.erb
+++ b/templates/client_config.erb
@@ -34,6 +34,8 @@ Job {
   FileSet  = "<%= @fileset %>"
 <% if @base -%>
   Base     = "<%= @base %>"
+<% end -%>
+<% if @accurate -%>
   Accurate = yes
 <% end -%>
   Storage  = "<%= @storage_server %>:storage:<%= @pool %>"

--- a/templates/client_config.erb
+++ b/templates/client_config.erb
@@ -47,6 +47,9 @@ Job {
   Pool     = "<%= @storage_server %>:pool:<%= @pool %>"
   Messages = "<%= @director_server %>:messages:standard"
   Rerun Failed Levels = <%= @rerun_failed_levels  ? 'yes':'no' %>
+<% if @allow_duplicate_jobs -%>
+  Allow Duplicate Jobs = yes
+<% end -%>
 <% if @run_scripts -%>
   <%- @run_scripts.each do |runscript| -%>
   RunScript {


### PR DESCRIPTION
If using Virtual Full backups it's advised to set Accurate = yes
This will be valid even though not using Base.

To be backward compatible I'm setting accurate = true if base is not undef.  

Added "Allow Duplicate Jobs", may be needed for Virtual Fulls as well