### PR TITLE
Allow referencing a JobDefs within the client job configuration

### DIFF
--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -25,11 +25,15 @@
 #
 # [*fileset*]
 #   The file set used by the client for backups
+#
 # [*base*]
 #   The job to use as a base.  Default to undef.
 #
 # [*accurate*]
 #   Set Accurate = yes for job definition (defaults to now unless *base* is specified)
+#
+# [*jobdefs*]
+#   Use defaults defined in the given JobDefs definition
 #
 # [*pool*]
 #   The pool used by the client for backups
@@ -120,6 +124,7 @@
 #     base              => 'LinuxBase',
 #     pool              => 'otherpool',
 #     storage_server    => 'bacula.example.com',
+#     jobdefs           => 'JobDefsName',
 #   }
 #
 # === Copyright
@@ -154,6 +159,7 @@ define bacula::client::config (
     undef   => false,
     default => true,
   },
+  Optional[String] $jobdefs             = undef,
   String $pool                          = 'default',
   Optional[String] $pool_diff           = "${pool}.differential",
   Optional[String] $pool_full           = "${pool}.full",

--- a/templates/client_config.erb
+++ b/templates/client_config.erb
@@ -38,6 +38,9 @@ Job {
 <% if @accurate -%>
   Accurate = yes
 <% end -%>
+<% if @jobdefs -%>
+  JobDefs = "<%= @jobdefs %>"
+<% end -%>
   Storage  = "<%= @storage_server %>:storage:<%= @pool %>"
   Spool Attributes = yes
 <% if @maximum_bandwidth -%>


### PR DESCRIPTION
This allows us to define some Job global job default values without the need to make the whole client job customise-able.