### PR TITLE
More configuration options for storage daemon

### DIFF
--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -77,6 +77,7 @@ class bacula::director (
   String $volume_retention_full             = '1 Year',
   String $volume_retention_incr             = '10 Days',
   String $storage_default_mount             = '/mnt/bacula',
+  Integer $max_concurrent_jobs              = 5,
   ) {
 
   include 'bacula::common'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -301,7 +301,7 @@ class bacula (
   Boolean $manage_logwatch               = true,
   String $operator_command               = "/usr/sbin/bsmtp -h localhost -f bacula@${::fqdn} -s \\\"Bacula Intervention Required (for %c)\\\" %r",
   String $plugin_dir                     = '/usr/lib64/bacula',
-  Optional[Array] $storage_hash           = undef,
+  Optional[Array] $storage_hash          = undef,
   Optional[Hash] $storage_device_hash    = undef,
   String $storage_default_mount          = '/mnt/bacula',
   String $storage_server                 = $director_server,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,9 @@
 # [*db_user_host*]
 #   The host string used by MySQL to allow connections from
 #
+# [*max_concurrent_jobs*]
+#   The Maxumum number of Concurrent Jobs, defaults to 5
+#
 # [*director_password*]
 #   The director's password
 #
@@ -105,6 +108,16 @@
 #
 # [*plugin_dir*]
 #   The directory Bacula plugins are stored in. Use this parameter if you are providing Bacula plugins for use. Only use if the package in the distro repositories supports plugins or you have included a respository with a newer Bacula packaged for your distro. If this is anything other than `undef` and you are not providing any plugins in this directory Bacula will throw an error every time it starts even if the package supports plugins.
+#
+# [*storage_hash*]
+#
+#   Allows you to define all resource definitions through an array of hashes using puppet or hiera.
+#   Example: {[{'Cloud' => {'DefaultCloudStorage' => { 'Driver' => 'S3', 'AccessKey' => 'XXXXXXXXXX',}}},{'Autochanger' => {'CloudChanger' => {'Changer Device' => '/dev/null', 'Changer Command' => '/dev/null'}}}]}
+#
+# [*storage_device_hash*]
+#
+#   Allows you to define the Device definition through a hash using puppet or hiera.
+#   Example: { 'DefaultFileStorage' => { 'Media Type' => 'File', 'Label Media' => yes,},}
 #
 # [*storage_default_mount*]
 #   Directory where the default disk for file backups is mounted. A subdirectory named <tt>default</tt> will be created allowing you
@@ -274,6 +287,7 @@ class bacula (
   Boolean $is_director                   = false,
   Boolean $is_storage                    = false,
   Boolean $logwatch_enabled              = true,
+  Integer $max_concurrent_jobs           = 5,
   String $mail_command                   = "/usr/sbin/bsmtp -h localhost -f bacula@${facts['fqdn']} -s \\\"Bacula %t %e (for %c)\\\" %r",
   String $mail_to                        = "root@${facts['fqdn']}",
   Optional[String] $mail_to_daemon       = $mail_to,
@@ -287,6 +301,8 @@ class bacula (
   Boolean $manage_logwatch               = true,
   String $operator_command               = "/usr/sbin/bsmtp -h localhost -f bacula@${::fqdn} -s \\\"Bacula Intervention Required (for %c)\\\" %r",
   String $plugin_dir                     = '/usr/lib64/bacula',
+  Optional[Array] $storage_hash           = undef,
+  Optional[Hash] $storage_device_hash    = undef,
   String $storage_default_mount          = '/mnt/bacula',
   String $storage_server                 = $director_server,
   Optional[String] $storage_template     = undef,
@@ -328,6 +344,7 @@ class bacula (
       db_port               => $db_port,
       db_user               => $db_user,
       db_user_host          => $db_user_host,
+      max_concurrent_jobs   => $max_concurrent_jobs,
       dir_template          => $director_template,
       director_password     => $director_password,
       director_server       => $director_server,
@@ -377,6 +394,8 @@ class bacula (
       director_password     => $director_password,
       director_server       => $director_server,
       plugin_dir            => $plugin_dir,
+      storage_hash          => $storage_hash,
+      storage_device_hash   => $storage_device_hash,
       storage_default_mount => $storage_default_mount,
       storage_server        => $storage_server,
       storage_template      => $storage_template,

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -54,15 +54,31 @@ class bacula::storage (
   Boolean $tls_verify_peer              = true,
   Boolean $use_tls                      = true,
   Boolean $block_checksum               = true,
+  Hash $storage_device_hash_default     = { 'DefaultFileStorage' => {
+    'Media Type'       => 'File',
+    'Archive Device'   => "$storage_default_mount/default",
+    'Label Media'      => yes,
+    'Random Access'    => yes,
+    'Automatic Mount'  => yes,
+    'Removable Media ' => no,
+    'Always Open'      => no,
+    'Block Checksum'   => $block_checksum ? {
+      default => yes,
+      no      => no,
+    },
+  },},
+  Hash $storage_device_hash             = {},
+  Array $storage_hash                   = {},
   ) {
 
   include 'bacula::common'
 
+  $_storage_device_hash = $storage_device_hash_default + $storage_device_hash
   package { $storage_package:
     ensure => installed,
   }
 
-  file { [$storage_default_mount, "${storage_default_mount}/default"]:
+  file { $storage_default_mount:
     ensure  => directory,
     owner   => 'bacula',
     group   => 'bacula',
@@ -70,7 +86,37 @@ class bacula::storage (
     seltype => 'bacula_store_t',
     require => Package[$storage_package],
   }
-
+  # create directories defined as Archive Device in the storage_device_hash
+  $_storage_device_hash.each |$name,$data| {
+    $data.filter |$key,$value| { $key == 'Archive Device' }.each |$key,$value| {
+      ensure_resource('file',$value,{
+        ensure  => directory,
+        owner   => 'bacula',
+        group   => 'bacula',
+        mode    => '0755',
+        seltype => 'bacula_store_t',
+        require => [Package[$storage_package],File[$storage_default_mount]],
+      })
+    }
+  }
+  if $storage_hash {
+    $storage_hash.each |$arr| {
+      $arr.each |$res,$cont| {
+        $cont.each |$name,$data| {
+          $data.filter |$key,$value| { $key == 'Archive Device' }.each |$key,$value| {
+            ensure_resource('file',$value,{
+              ensure  => directory,
+              owner   => 'bacula',
+              group   => 'bacula',
+              mode    => '0755',
+              seltype => 'bacula_store_t',
+              require => [Package[$storage_package],File[$storage_default_mount]],
+            })
+          }
+        }
+      }
+    }
+  }
   if $facts['osfamily'] == 'RedHat' and $facts['selinux'] {
     selinux::fcontext { "${storage_default_mount}(/.*)?":
       seltype => 'bacula_store_t',
@@ -114,7 +160,6 @@ class bacula::storage (
     content   => template($storage_template),
     require   => $file_requires,
     notify    => Service['bacula-sd'],
-    show_diff => false,
   }
 
   # Register the Service so we can manage it through Puppet

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -68,7 +68,7 @@ class bacula::storage (
     },
   },},
   Hash $storage_device_hash             = {},
-  Array $storage_hash                   = {},
+  Array $storage_hash                   = [],
   ) {
 
   include 'bacula::common'

--- a/templates/bacula-dir.conf.erb
+++ b/templates/bacula-dir.conf.erb
@@ -13,7 +13,7 @@ Director {
 <% if @plugin_dir -%>
   Plugin Directory = <%= @plugin_dir %>
 <% end -%>
-  Maximum Concurrent Jobs = 5
+  Maximum Concurrent Jobs = <%= @max_concurrent_jobs %>
   Password = "<%= @director_password -%>"
   Messages = "<%= @director_server -%>:messages:daemon"
 <% if @use_tls -%>

--- a/templates/bacula-sd.conf.erb
+++ b/templates/bacula-sd.conf.erb
@@ -71,18 +71,33 @@ Director {
   Monitor = yes
 }
 
-# not configure the default Device this Storage Daemon will provide
+# Define the Devices this Storage Daemon will provide
+<% if @_storage_device_hash -%>
+  <%- @_storage_device_hash.each do |name,data| -%>
 Device {
-  Name = "DefaultFileStorage"
-  Media Type = File
-  Archive Device = <%= @storage_default_mount %>/default
-  Label Media = yes
-  Random Access = yes
-  Automatic Mount = yes
-  Removable Media = no
-  Always Open = no
-  Block Checksum = <%= @block_checksum ? 'yes':'no' %>
+  Name = "<%= name %>"
+    <%- data.each do |key,value| -%>
+  <%= key %> = <%= value %>
+    <%- end -%>
 }
+  <%- end -%>
+<%- end -%>
+
+# Define the Cloud definitions this Storage Daemon will provide
+<% if @storage_hash -%>
+  <%- @storage_hash.each do |arr| -%>
+    <%- arr.each do |resource,content| -%>
+<%= resource %> {
+      <%- content.each do |name,data| -%>
+  Name = "<%= name %>"
+        <%- data.each do |key,value| -%>
+  <%= key %> = <%= value %>
+        <%- end -%>
+      <%- end -%>
+}
+    <%- end -%>
+  <%- end -%>
+<%- end -%>
 
 # All other Devices are created by the clients that need them - each will
 # prepare their own device and pool configuration, which will then be


### PR DESCRIPTION
Allow defining storage daemon settings with two new hashes.

storage_device_hash
This allows to configure storage devices on the storage daemon using a
hiera or puppet hash.
Should be backward compatible as it uses the former default as default
hash.

storage_hash (which is an array of hashes, actually)
As there are some new resources in bacula 9.4 which aren't covered by
this module I created this array of hashes that allows to configure any
resource which might be needed. It's an array as a hash would not allow
to define one resource type twice as hash keys are merged if not unique.
